### PR TITLE
fix: Allow empty tables as field types

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -168,7 +168,9 @@ fn parse_function(pair: Pair<Rule>) -> Type {
 fn parse_table(pair: Pair<Rule>) -> Type {
     assert_eq!(pair.as_rule(), Rule::table_def);
 
-    let pair = pair.into_inner().next().unwrap();
+    let Some(pair) = pair.into_inner().next() else {
+        return Type::table(Vec::new())
+    };
 
     assert_eq!(pair.as_rule(), Rule::table_fields);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -270,6 +270,7 @@ impl Type {
                     .join(", ");
                 format!("[{tys}]")
             }
+            TypeInner::TableDef(table) if table.fields.is_empty() => "{}".to_string(),
             TypeInner::TableDef(table) => {
                 let fields = table
                     .fields
@@ -393,6 +394,7 @@ impl std::fmt::Display for Type {
                     .join(", ");
                 format!("[{tys}]")
             }
+            TypeInner::TableDef(table) if table.fields.is_empty() => "{}".to_string(),
             TypeInner::TableDef(table) => {
                 let fields = table
                     .fields


### PR DESCRIPTION
problem: annotation.rs::parse_table function crash if a field is defined as `{}`.

cause: The `parse_table` was calling unwrap on an option. However if `{}` is used as a field type, this call return None, causing a crash.

solution: Since {} is a valid (but empty) table literal, we return an empty Vec in parse_table and generate "{}" in `Type::format_with_link()` when we encounter an empty table.